### PR TITLE
Make API version configurable; add prepublish compilation

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -16,7 +16,7 @@ exports.connect = (options={}) ->
 
 
   api.call = (functionName, functionArgs, callback) ->
-    rootPath = '/api/1.2.1/'
+    rootPath = api.options.rootPath or '/api/1.2.1/'
     apiOptions = _.extend { 'apikey': @options.apikey }, functionArgs
     httpOptions =
       host: @options.host

--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@
     (_base1 = api.options).port || (_base1.port = 9001);
     api.call = function(functionName, functionArgs, callback) {
       var apiOptions, chunks, httpOptions, req, rootPath;
-      rootPath = '/api/1/';
+      rootPath = api.options.rootPath || '/api/1.2.1/';
       apiOptions = _.extend({
         'apikey': this.options.apikey
       }, functionArgs);
@@ -66,7 +66,7 @@
         }, null);
       });
     };
-    apiFunctions = ['createGroup', 'createGroupIfNotExistsFor', 'deleteGroup', 'listPads', 'createGroupPad', 'listAllGroups', 'createAuthor', 'createAuthorIfNotExistsFor', 'listPadsOfAuthor', 'getAuthorName', 'createSession', 'deleteSession', 'getSessionInfo', 'listSessionsOfGroup', 'listSessionsOfAuthor', 'getText', 'setText', 'getHTML', 'createPad', 'getRevisionsCount', 'padUsersCount', 'padUsers', 'deletePad', 'getReadOnlyID', 'setPublicStatus', 'getPublicStatus', 'setPassword', 'isPasswordProtected', 'listAuthorsOfPad', 'getLastEdited', 'sendClientsMessage'];
+    apiFunctions = ['createGroup', 'createGroupIfNotExistsFor', 'deleteGroup', 'listPads', 'createGroupPad', 'listAllGroups', 'createAuthor', 'createAuthorIfNotExistsFor', 'listPadsOfAuthor', 'getAuthorName', 'createSession', 'deleteSession', 'getSessionInfo', 'listSessionsOfGroup', 'listSessionsOfAuthor', 'getText', 'setText', 'getHTML', 'createPad', 'getRevisionsCount', 'padUsersCount', 'padUsers', 'deletePad', 'getReadOnlyID', 'setPublicStatus', 'getPublicStatus', 'setPassword', 'isPasswordProtected', 'listAuthorsOfPad', 'getLastEdited', 'sendClientsMessage', 'listAllPads'];
     _fn = function(functionName) {
       return api[functionName] = function(args, callback) {
         if (arguments.length === 1 && _.isFunction(args)) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
   "dependencies": {
     "underscore": "1.3.x"
   },
+  "devDependencies": {
+    "coffee-script": "~1"
+  },
+  "scripts": {
+    "prepublish": "cake build"
+  },
   "main": "./main.js",
   "license": "MIT",
   "engines": { "node": ">= 0.4.0" }


### PR DESCRIPTION
- Take an option in the constructor to allow setting rootPath, and
  consequently allow flexibility on API versions.
  - Add a prepublish hook to compile coffee-script so the coffee/js
    are never out of sync.
