### PR TITLE
fix empty response for API calls > 1.0

### DIFF
--- a/main.js
+++ b/main.js
@@ -57,7 +57,11 @@
             return;
           }
           if (response.code === 0 && response.message === 'ok') {
-            return callback(null, response.data);
+              if (response.data){
+                  return callback(null, response.data);
+              }else{
+                  return callback(null, response);
+              }
           } else {
             return callback({
               code: response.code,


### PR DESCRIPTION
When using rootPath: "/api/1.2.13/", at least for api calls deletePad and createPad, the response data was empty